### PR TITLE
OvhRequestApi: Ensure to escape querystring arguments

### DIFF
--- a/contrib/jsonsh-lib.sh
+++ b/contrib/jsonsh-lib.sh
@@ -114,7 +114,7 @@ _JSonSH_rewrite_output()
 
        ## Actions on json key :
        # 1) remove some chars : brackets and double quotes
-       gsub(/\[|\]|\"/,"",json_key)
+       gsub(/\[|\]|"/,"",json_key)
        # 2) detect array index between comma, put digits between brackets
        json_key = gensub(/(,([[:digit:]]+)(,|))/,"[\\2]\\3","g",json_key)
        # 3) replace each comma with dot

--- a/contrib/ovh-api-lib.sh
+++ b/contrib/ovh-api-lib.sh
@@ -54,6 +54,8 @@ OvhRequestApi()
   cmd_profile=${cmd[*]}
 
   if [ -n "${url}" ]; then
+    # escape querystring arguments
+    url=$(printf "%q" "${url}")
     cmd+=(--url "${url}")
   fi
 


### PR DESCRIPTION
- [MAJOR] previously, only the first querystring argument was sent to OVH API, because ampersand was interpreted as shell background job, so other arguments ignored

misc:
- [MINOR] fix jsonsh-lib about AWK pattern warning